### PR TITLE
fix: correct repository URL to zed-todo-highlighter

### DIFF
--- a/extension/extension.toml
+++ b/extension/extension.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 schema_version = 1
 authors = ["Shion Ito <frontier.engine+github@gmail.com>"]
 description = "Highlights TODO, FIXME, HACK, NOTE, WARN, BUG and other keywords across all file types"
-repository = "https://github.com/shionit/todo-highlighter"
+repository = "https://github.com/shionit/zed-todo-highlighter"
 
 [language_servers.todo-highlighter-lsp]
 name = "TODO Highlighter LSP"

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -93,7 +93,7 @@ impl TodoHighlighterExtension {
 
         if !std::path::Path::new(&binary_path).exists() {
             let url = format!(
-                "https://github.com/shionit/todo-highlighter/releases/download/v{LSP_VERSION}/{binary_name}"
+                "https://github.com/shionit/zed-todo-highlighter/releases/download/v{LSP_VERSION}/{binary_name}"
             );
             zed::download_file(&url, &binary_path, DownloadedFileType::Uncompressed)
                 .map_err(|e| format!("Failed to download {binary_name} v{LSP_VERSION}: {e}"))?;


### PR DESCRIPTION
## Summary
- Fix `repository` field in `extension/extension.toml` (was `todo-highlighter`, should be `zed-todo-highlighter`)
- Fix binary download URL in `extension/src/lib.rs` (same wrong repo name)

Both references pointed to a non-existent repository and would have broken binary downloads for users.

## Test plan
- [x] WASM build passes (`cargo check -p todo-highlighter-extension --target wasm32-wasip1`)