### PR TITLE
fix: add shell: bash to build steps for Windows compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,14 @@ jobs:
         if: matrix.use_cross
         env:
           TARGET: ${{ matrix.target }}
+        shell: bash
         run: cross build --release -p todo-highlighter-lsp --target "$TARGET"
 
       - name: Build (native)
         if: '!matrix.use_cross'
         env:
           TARGET: ${{ matrix.target }}
+        shell: bash
         run: cargo build --release -p todo-highlighter-lsp --target "$TARGET"
 
       - name: Package binary and generate SHA-256 checksum


### PR DESCRIPTION
## Summary
- Add `shell: bash` to `Build (cross-compiled)` and `Build (native)` steps

## Root cause
Windows runners default to PowerShell, where `$TARGET` evaluates as empty (env vars require `$env:TARGET` syntax in PowerShell). Adding `shell: bash` forces Git Bash on all platforms, making `$TARGET` expand correctly.

## Test plan
- [x] Re-run release CI after merge and tag — Windows builds should pass