### PR TITLE
ci: update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             bin_suffix: .exe
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -79,7 +79,7 @@ jobs:
             shasum -a 256 "$BIN" | awk '{print $1}' > "${BIN}.sha256"
           fi
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.target }}
           path: |
@@ -91,12 +91,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
 
       - name: Publish release with binaries and checksums
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: todo-highlighter-lsp-*
         env:


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` v4 → **v6.0.2**
- Bumps `actions/upload-artifact` v4 → **v7.0.1**
- Bumps `actions/download-artifact` v4 → **v8.0.1**
- Bumps `softprops/action-gh-release` v2 → **v3.0.0**

All four actions were flagged in the [v0.1.0 release run](https://github.com/shionit/zed-todo-highlighter/actions/runs/26339925750) as running on Node.js 20, which GitHub will force to Node.js 24 on **June 2, 2026** and remove entirely on September 16, 2026. No workflow logic was changed — only the pinned commit SHAs.

## Test plan

- [x] Merge and push a new tag (or re-run a workflow manually) to confirm no Node.js 20 deprecation warnings appear in the build logs
- [x] Verify all 6 platform binaries are uploaded and the GitHub Release is created successfully