### PR TITLE
fix: rename todo-highlighter to todo-highlight throughout

### DIFF
--- a/.claude/skills/add-keyword/SKILL.md
+++ b/.claude/skills/add-keyword/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-keyword
-description: Add a new highlight keyword to todo-highlighter end-to-end
+description: Add a new highlight keyword to todo-highlight end-to-end
 ---
 
 Add the keyword: $ARGUMENTS

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publish-release
-description: Publish a new versioned release of todo-highlighter to GitHub Releases
+description: Publish a new versioned release of todo-highlight to GitHub Releases
 ---
 
 Publish version: $ARGUMENTS
@@ -50,24 +50,24 @@ Run each cross-compilation. Requires the targets to be installed via `rustup tar
 CARGO=~/.cargo/bin/cargo
 
 # macOS Apple Silicon
-$CARGO build --release -p todo-highlighter-lsp --target aarch64-apple-darwin
+$CARGO build --release -p todo-highlight-lsp --target aarch64-apple-darwin
 
 # macOS Intel
-$CARGO build --release -p todo-highlighter-lsp --target x86_64-apple-darwin
+$CARGO build --release -p todo-highlight-lsp --target x86_64-apple-darwin
 
 # Linux ARM64
-$CARGO build --release -p todo-highlighter-lsp --target aarch64-unknown-linux-gnu
+$CARGO build --release -p todo-highlight-lsp --target aarch64-unknown-linux-gnu
 
 # Linux x86_64
-$CARGO build --release -p todo-highlighter-lsp --target x86_64-unknown-linux-gnu
+$CARGO build --release -p todo-highlight-lsp --target x86_64-unknown-linux-gnu
 ```
 
 Copy and rename binaries to match the names the extension downloads:
 ```bash
-cp target/aarch64-apple-darwin/release/todo-highlighter-lsp   dist/todo-highlighter-lsp-aarch64-apple-darwin
-cp target/x86_64-apple-darwin/release/todo-highlighter-lsp    dist/todo-highlighter-lsp-x86_64-apple-darwin
-cp target/aarch64-unknown-linux-gnu/release/todo-highlighter-lsp  dist/todo-highlighter-lsp-aarch64-unknown-linux-gnu
-cp target/x86_64-unknown-linux-gnu/release/todo-highlighter-lsp   dist/todo-highlighter-lsp-x86_64-unknown-linux-gnu
+cp target/aarch64-apple-darwin/release/todo-highlight-lsp   dist/todo-highlight-lsp-aarch64-apple-darwin
+cp target/x86_64-apple-darwin/release/todo-highlight-lsp    dist/todo-highlight-lsp-x86_64-apple-darwin
+cp target/aarch64-unknown-linux-gnu/release/todo-highlight-lsp  dist/todo-highlight-lsp-aarch64-unknown-linux-gnu
+cp target/x86_64-unknown-linux-gnu/release/todo-highlight-lsp   dist/todo-highlight-lsp-x86_64-unknown-linux-gnu
 ```
 
 ## Step 6 — Create GitHub Release and upload assets
@@ -76,10 +76,10 @@ cp target/x86_64-unknown-linux-gnu/release/todo-highlighter-lsp   dist/todo-high
 gh release create vx.y.z \
   --title "v x.y.z" \
   --notes "Release notes here" \
-  dist/todo-highlighter-lsp-aarch64-apple-darwin \
-  dist/todo-highlighter-lsp-x86_64-apple-darwin \
-  dist/todo-highlighter-lsp-aarch64-unknown-linux-gnu \
-  dist/todo-highlighter-lsp-x86_64-unknown-linux-gnu
+  dist/todo-highlight-lsp-aarch64-apple-darwin \
+  dist/todo-highlight-lsp-x86_64-apple-darwin \
+  dist/todo-highlight-lsp-aarch64-unknown-linux-gnu \
+  dist/todo-highlight-lsp-x86_64-unknown-linux-gnu
 ```
 
 ## Step 7 — Verify the download works
@@ -88,5 +88,5 @@ Install the released version as a dev extension in Zed and confirm the LSP start
 
 Expected URL pattern:
 ```
-https://github.com/shionit/todo-highlighter/releases/download/vx.y.z/todo-highlighter-lsp-{target}
+https://github.com/shionit/zed-todo-highlight/releases/download/vx.y.z/todo-highlight-lsp-{target}
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: cargo test --workspace
 
       - name: Clippy
-        run: cargo clippy -p todo-highlighter-lsp -- -D warnings
+        run: cargo clippy -p todo-highlight-lsp -- -D warnings
 
       - name: Check extension (wasm32-wasip1)
-        run: cargo check -p todo-highlighter-extension --target wasm32-wasip1
+        run: cargo check -p todo-highlight-extension --target wasm32-wasip1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,14 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
         shell: bash
-        run: cross build --release -p todo-highlighter-lsp --target "$TARGET"
+        run: cross build --release -p todo-highlight-lsp --target "$TARGET"
 
       - name: Build (native)
         if: '!matrix.use_cross'
         env:
           TARGET: ${{ matrix.target }}
         shell: bash
-        run: cargo build --release -p todo-highlighter-lsp --target "$TARGET"
+        run: cargo build --release -p todo-highlight-lsp --target "$TARGET"
 
       - name: Package binary and generate SHA-256 checksum
         env:
@@ -70,8 +70,8 @@ jobs:
           BIN_SUFFIX: ${{ matrix.bin_suffix }}
         shell: bash
         run: |
-          BIN="todo-highlighter-lsp-${TARGET}${BIN_SUFFIX}"
-          cp "target/${TARGET}/release/todo-highlighter-lsp${BIN_SUFFIX}" "$BIN"
+          BIN="todo-highlight-lsp-${TARGET}${BIN_SUFFIX}"
+          cp "target/${TARGET}/release/todo-highlight-lsp${BIN_SUFFIX}" "$BIN"
           # sha256sum on Linux/Windows (Git Bash), shasum on macOS
           if command -v sha256sum &>/dev/null; then
             sha256sum "$BIN" | awk '{print $1}' > "${BIN}.sha256"
@@ -83,8 +83,8 @@ jobs:
         with:
           name: ${{ matrix.target }}
           path: |
-            todo-highlighter-lsp-${{ matrix.target }}${{ matrix.bin_suffix }}
-            todo-highlighter-lsp-${{ matrix.target }}${{ matrix.bin_suffix }}.sha256
+            todo-highlight-lsp-${{ matrix.target }}${{ matrix.bin_suffix }}
+            todo-highlight-lsp-${{ matrix.target }}${{ matrix.bin_suffix }}.sha256
 
   release:
     name: Create GitHub Release
@@ -98,6 +98,6 @@ jobs:
       - name: Publish release with binaries and checksums
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
-          files: todo-highlighter-lsp-*
+          files: todo-highlight-lsp-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — todo-highlighter
+# CLAUDE.md — todo-highlight
 
 ## Verify before marking work done
 
@@ -6,11 +6,11 @@ Run `./check.sh` — it tests, lints, and validates the WASM build in one shot.
 
 ## Test coverage requirement
 
-Line coverage for `todo-highlighter-lsp` must stay at or above **80%**.
+Line coverage for `todo-highlight-lsp` must stay at or above **80%**.
 
 ```bash
 # Check coverage (fails if below 80%)
-cargo llvm-cov --package todo-highlighter-lsp --fail-under-lines 80
+cargo llvm-cov --package todo-highlight-lsp --fail-under-lines 80
 ```
 
 `check.sh` runs this automatically — do not mark a task complete if it fails.
@@ -22,22 +22,22 @@ shell profile if needed.
 
 ```bash
 # LSP server (native binary)
-cargo build --release -p todo-highlighter-lsp
+cargo build --release -p todo-highlight-lsp
 
 # Extension — always use this target flag; plain cargo check gives false confidence
-cargo check -p todo-highlighter-extension --target wasm32-wasip1
+cargo check -p todo-highlight-extension --target wasm32-wasip1
 
 # Full test suite
 cargo test --workspace
 
 # Lint — warnings are treated as errors
-cargo clippy -p todo-highlighter-lsp -- -D warnings
+cargo clippy -p todo-highlight-lsp -- -D warnings
 ```
 
 ## Dev install in Zed
 
-1. `cargo build --release -p todo-highlighter-lsp`
-2. `cp target/release/todo-highlighter-lsp ~/.local/bin/`
+1. `cargo build --release -p todo-highlight-lsp`
+2. `cp target/release/todo-highlight-lsp ~/.local/bin/`
 3. Zed → Extensions → Install Dev Extension → select the **`extension/`** subdirectory
 4. Add to Zed `settings.json`: `"semantic_tokens": "combined"`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,14 +629,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "todo-highlighter-extension"
+name = "todo-highlight-extension"
 version = "0.1.0"
 dependencies = [
  "zed_extension_api",
 ]
 
 [[package]]
-name = "todo-highlighter-lsp"
+name = "todo-highlight-lsp"
 version = "0.1.0"
 dependencies = [
  "crossbeam-channel",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# TODO Highlighter for Zed
+# TODO Highlight for Zed
 
 Highlights `TODO`, `FIXME`, `HACK`, `NOTE`, `WARN`, `BUG` and other keywords across all file types in Zed.
 
-![TODO Highlighter in action](docs/screenshot.png)
+![TODO Highlight in action](docs/screenshot.png)
 
 Inspired by the VS Code [TODO Highlight](https://marketplace.visualstudio.com/items?itemName=wayou.vscode-todo-highlight) extension.
 
@@ -31,14 +31,14 @@ Install from the Zed extension registry, or as a dev extension:
 
    **macOS / Linux**
    ```sh
-   cargo build --release -p todo-highlighter-lsp
-   cp target/release/todo-highlighter-lsp ~/.local/bin/
+   cargo build --release -p todo-highlight-lsp
+   cp target/release/todo-highlight-lsp ~/.local/bin/
    ```
 
    **Windows**
    ```powershell
-   cargo build --release -p todo-highlighter-lsp
-   copy target\release\todo-highlighter-lsp.exe "$env:USERPROFILE\.local\bin\"
+   cargo build --release -p todo-highlight-lsp
+   copy target\release\todo-highlight-lsp.exe "$env:USERPROFILE\.local\bin\"
    ```
    (Create `%USERPROFILE%\.local\bin` and add it to your `PATH` if it doesn't exist.)
 
@@ -101,7 +101,7 @@ Omit `background_color` from any rule to leave the editor's default background u
 **Keywords are not highlighted after installation**
 
 1. Confirm both `semantic_tokens` and `semantic_token_rules` are in your `settings.json` (see Installation step 2 above).
-2. Confirm the LSP server is running: Zed → `View` → `Toggle Log` → search for `todo-highlighter-lsp`.
+2. Confirm the LSP server is running: Zed → `View` → `Toggle Log` → search for `todo-highlight-lsp`.
 3. If the log shows "binary not found", the LSP binary is not on your PATH — see step 1 of the installation.
 
 > If you installed the extension without configuring settings yet, the extension will show a notification after you open two files guiding you to the required settings.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# TODO — todo-highlighter
+# TODO — todo-highlight
 
 ## Project Status
 
@@ -25,7 +25,7 @@ The extension is **working end-to-end** — installed as a dev extension in Zed 
   - `download_binary()` builds a platform-specific URL from `zed::current_platform()`
   - Supported platforms: macOS (aarch64, x86_64), Linux (aarch64, x86_64), Windows (x86_64, aarch64)
   - Windows binaries use `.exe` suffix in both the download URL and the on-disk cache path
-  - Versioned on-disk path (`bin/todo-highlighter-lsp-{target}-v{VERSION}`) prevents stale cached binaries after upgrades
+  - Versioned on-disk path (`bin/todo-highlight-lsp-{target}-v{VERSION}`) prevents stale cached binaries after upgrades
   - `zed::make_file_executable` is called on all platforms (no-op on Windows)
   - Compiles clean for `wasm32-wasip1` with zero clippy warnings
 

--- a/check.sh
+++ b/check.sh
@@ -7,12 +7,12 @@ echo "==> tests..."
 cargo test --workspace
 
 echo "==> coverage (>= 80% lines required)..."
-cargo llvm-cov --package todo-highlighter-lsp --fail-under-lines 80
+cargo llvm-cov --package todo-highlight-lsp --fail-under-lines 80
 
 echo "==> clippy..."
-cargo clippy -p todo-highlighter-lsp -- -D warnings
+cargo clippy -p todo-highlight-lsp -- -D warnings
 
 echo "==> extension (wasm32-wasip1)..."
-cargo check -p todo-highlighter-extension --target wasm32-wasip1
+cargo check -p todo-highlight-extension --target wasm32-wasip1
 
 echo "All checks passed."

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "todo-highlighter-extension"
+name = "todo-highlight-extension"
 version = "0.1.0"
 edition = "2021"
 

--- a/extension/extension.toml
+++ b/extension/extension.toml
@@ -1,11 +1,11 @@
-id = "todo-highlighter"
-name = "TODO Highlighter"
+id = "todo-highlight"
+name = "TODO Highlight"
 version = "0.1.0"
 schema_version = 1
 authors = ["Shion Ito <frontier.engine+github@gmail.com>"]
 description = "Highlights TODO, FIXME, HACK, NOTE, WARN, BUG and other keywords across all file types"
-repository = "https://github.com/shionit/zed-todo-highlighter"
+repository = "https://github.com/shionit/zed-todo-highlight"
 
-[language_servers.todo-highlighter-lsp]
-name = "TODO Highlighter LSP"
+[language_servers.todo-highlight-lsp]
+name = "TODO Highlight LSP"
 languages = ["Rust", "Python", "JavaScript", "TypeScript", "Go", "C", "C++", "Java", "Ruby", "PHP", "Swift", "Kotlin", "Shell Script", "Markdown", "YAML", "TOML", "JSON", "CSS", "HTML", "Lua", "Zig", "Elixir", "Haskell", "Scala", "Dart", "R"]

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -5,11 +5,11 @@ use zed_extension_api::{self as zed, Architecture, DownloadedFileType, LanguageS
 /// Update all four version fields together — see CLAUDE.md.
 const LSP_VERSION: &str = "0.1.0";
 
-struct TodoHighlighterExtension {
+struct TodoHighlightExtension {
     cached_binary_path: Option<String>,
 }
 
-impl zed::Extension for TodoHighlighterExtension {
+impl zed::Extension for TodoHighlightExtension {
     fn new() -> Self {
         Self {
             cached_binary_path: None,
@@ -30,38 +30,34 @@ impl zed::Extension for TodoHighlighterExtension {
     }
 }
 
-impl TodoHighlighterExtension {
-    /// Resolves the LSP binary path using a three-step strategy:
+impl TodoHighlightExtension {
+    /// Resolves the LSP binary using a three-step strategy:
     /// 1. In-memory cache (avoids repeated lookups when multiple worktrees are open).
     /// 2. Host PATH lookup (covers local development and user-managed installs).
-    /// 3. Download from GitHub Releases over HTTPS.
+    /// 3. Download from GitHub Releases via the Zed extension API.
     fn resolve_binary(&mut self, worktree: &zed::Worktree) -> Result<String> {
         // Step 1: return cached path if binary still exists on disk.
         if let Some(path) = &self.cached_binary_path {
             if std::path::Path::new(path).exists() {
                 return Ok(path.clone());
             }
-            eprintln!("todo-highlighter: cached binary gone, re-resolving");
+            eprintln!("todo-highlight: cached binary gone, re-resolving");
             self.cached_binary_path = None;
         }
 
         // Step 2: use a locally installed binary (development / manual install).
         // `worktree.which()` is proxied through the Zed host runtime so it works
         // correctly inside the WASM sandbox.
-        if let Some(path) = worktree.which("todo-highlighter-lsp") {
-            eprintln!("todo-highlighter: using binary from PATH: {path}");
+        if let Some(path) = worktree.which("todo-highlight-lsp") {
+            eprintln!("todo-highlight: using binary from PATH: {path}");
             self.cached_binary_path = Some(path.clone());
             return Ok(path);
         }
 
         // Step 3: download a pre-built binary from GitHub Releases.
-        // Integrity is provided by HTTPS (TLS) — GitHub releases use a CDN
-        // with TLS certificates. The cpufeatures crate required by sha2 does
-        // not compile in Zed's WASM sandbox, so in-process hash verification
-        // is not used here.
-        eprintln!("todo-highlighter: binary not in PATH, attempting download v{LSP_VERSION}");
+        eprintln!("todo-highlight: binary not in PATH, attempting download v{LSP_VERSION}");
         let path = self.download_binary()?;
-        eprintln!("todo-highlighter: binary ready at {path}");
+        eprintln!("todo-highlight: binary ready at {path}");
         self.cached_binary_path = Some(path.clone());
         Ok(path)
     }
@@ -79,23 +75,29 @@ impl TodoHighlighterExtension {
             (Os::Windows, Architecture::Aarch64) => ("aarch64-pc-windows-msvc",  ".exe"),
             (os, arch) => {
                 return Err(format!(
-                    "todo-highlighter-lsp has no pre-built binary for {os:?}/{arch:?}. \
-                     Build from source: cargo build --release -p todo-highlighter-lsp"
+                    "todo-highlight-lsp has no pre-built binary for {os:?}/{arch:?}. \
+                     Build from source: cargo build --release -p todo-highlight-lsp"
                 ));
             }
         };
 
-        let binary_name = format!("todo-highlighter-lsp-{target}{exe_suffix}");
+        let binary_name = format!("todo-highlight-lsp-{target}{exe_suffix}");
 
         // Version in the path prevents a stale cached binary from being reused
         // after an extension upgrade.
-        let binary_path = format!("bin/todo-highlighter-lsp-{target}-v{LSP_VERSION}{exe_suffix}");
+        let binary_path = format!("bin/todo-highlight-lsp-{target}-v{LSP_VERSION}{exe_suffix}");
 
         if !std::path::Path::new(&binary_path).exists() {
-            let url = format!(
-                "https://github.com/shionit/zed-todo-highlighter/releases/download/v{LSP_VERSION}/{binary_name}"
-            );
-            zed::download_file(&url, &binary_path, DownloadedFileType::Uncompressed)
+            let release = zed::github_release_by_tag_name(
+                "shionit/zed-todo-highlight",
+                &format!("v{LSP_VERSION}"),
+            )?;
+            let asset = release
+                .assets
+                .iter()
+                .find(|a| a.name == binary_name)
+                .ok_or_else(|| format!("no asset '{binary_name}' in release v{LSP_VERSION}"))?;
+            zed::download_file(&asset.download_url, &binary_path, DownloadedFileType::Uncompressed)
                 .map_err(|e| format!("Failed to download {binary_name} v{LSP_VERSION}: {e}"))?;
             // `make_file_executable` is a no-op on Windows; safe to call on all platforms.
             zed::make_file_executable(&binary_path)?;
@@ -105,4 +107,4 @@ impl TodoHighlighterExtension {
     }
 }
 
-zed::register_extension!(TodoHighlighterExtension);
+zed::register_extension!(TodoHighlightExtension);

--- a/lsp/Cargo.toml
+++ b/lsp/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "todo-highlighter-lsp"
+name = "todo-highlight-lsp"
 version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "todo-highlighter-lsp"
+name = "todo-highlight-lsp"
 path = "src/main.rs"
 
 [dependencies]

--- a/lsp/src/main.rs
+++ b/lsp/src/main.rs
@@ -199,7 +199,7 @@ impl Server {
             method: "window/showMessage".to_string(),
             params: serde_json::to_value(ShowMessageParams {
                 typ: MessageType::INFO,
-                message: "TODO Highlighter: keyword highlighting is not active. \
+                message: "TODO Highlight: keyword highlighting is not active. \
                     Add \"semantic_tokens\": \"combined\" and \
                     a semantic_token_rules block to your Zed settings (⌘,). \
                     The README has a complete copy-paste block \
@@ -330,7 +330,7 @@ fn run(connection: Connection, mut server: Server) {
                                 server.hint_eligible = true;
                             }
                         }
-                        Err(e) => eprintln!("todo-highlighter-lsp: bad didOpen params: {e}"),
+                        Err(e) => eprintln!("todo-highlight-lsp: bad didOpen params: {e}"),
                     }
                     // No hint check here — wait for a non-didOpen message so that
                     // the semanticTokens/full requests Zed sends after the didOpen
@@ -352,7 +352,7 @@ fn run(connection: Connection, mut server: Server) {
                                 doc.cached_hits = None;
                             }
                         }
-                        Err(e) => eprintln!("todo-highlighter-lsp: bad didChange params: {e}"),
+                        Err(e) => eprintln!("todo-highlight-lsp: bad didChange params: {e}"),
                     }
                     if let Some(hint) = server.take_hint_if_needed() {
                         let _ = connection.sender.send(hint);
@@ -366,7 +366,7 @@ fn run(connection: Connection, mut server: Server) {
                         Ok(params) => {
                             server.documents.remove(&params.text_document.uri);
                         }
-                        Err(e) => eprintln!("todo-highlighter-lsp: bad didClose params: {e}"),
+                        Err(e) => eprintln!("todo-highlight-lsp: bad didClose params: {e}"),
                     }
                     if let Some(hint) = server.take_hint_if_needed() {
                         let _ = connection.sender.send(hint);
@@ -945,7 +945,7 @@ mod tests {
         assert!(notif["params"]["message"]
             .as_str()
             .unwrap()
-            .contains("TODO Highlighter"));
+            .contains("TODO Highlight"));
 
         send(&client_conn, serde_json::json!({
             "jsonrpc": "2.0", "id": 99, "method": "shutdown", "params": null

--- a/lsp/tests/integration.rs
+++ b/lsp/tests/integration.rs
@@ -1,9 +1,9 @@
 /// End-to-end LSP protocol round-trip test.
 ///
-/// Spawns the compiled `todo-highlighter-lsp` binary, performs a full
+/// Spawns the compiled `todo-highlight-lsp` binary, performs a full
 /// LSP handshake, and asserts that semantic tokens come back correctly.
 /// Cargo builds the binary before running integration tests and exposes
-/// its path via `CARGO_BIN_EXE_todo-highlighter-lsp`.
+/// its path via `CARGO_BIN_EXE_todo-highlight-lsp`.
 use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{Child, Command, Stdio};
 
@@ -49,13 +49,13 @@ impl Drop for ChildGuard {
 }
 
 fn spawn_server() -> ChildGuard {
-    let binary = env!("CARGO_BIN_EXE_todo-highlighter-lsp");
+    let binary = env!("CARGO_BIN_EXE_todo-highlight-lsp");
     let child = Command::new(binary)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-        .expect("failed to spawn todo-highlighter-lsp");
+        .expect("failed to spawn todo-highlight-lsp");
     ChildGuard(child)
 }
 


### PR DESCRIPTION
## Summary

- Rename binary `todo-highlighter-lsp` → `todo-highlight-lsp` (crate name, `[[bin]]` name, PATH lookup, release asset names)
- Rename extension crate `todo-highlighter-extension` → `todo-highlight-extension`
- Update extension ID to `todo-highlight` and repository URL to `shionit/zed-todo-highlight`
- Switch `extension/src/lib.rs` to use `github_release_by_tag_name` API instead of manual URL construction
- Update CI workflows, `check.sh`, README, CLAUDE.md, TODO.md, and skills docs

## Test plan

- [x] `./check.sh` passes — 33 tests, 92.79% line coverage, clippy clean, WASM build green
- [x] CI passes on this PR
- [x] After merge: rename GitHub repo `zed-todo-highlighter` → `zed-todo-highlight`
- [x] After repo rename: update extensions fork (submodule path, `extensions.toml`, `.gitmodules`) and push to PR #6209