### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,14 +630,14 @@ dependencies = [
 
 [[package]]
 name = "todo-highlight-extension"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "zed_extension_api",
 ]
 
 [[package]]
 name = "todo-highlight-lsp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossbeam-channel",
  "lsp-server",

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-highlight-extension"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/extension/extension.toml
+++ b/extension/extension.toml
@@ -1,6 +1,6 @@
 id = "todo-highlight"
 name = "TODO Highlight"
-version = "0.1.0"
+version = "0.2.0"
 schema_version = 1
 authors = ["Shion Ito <frontier.engine+github@gmail.com>"]
 description = "Highlights TODO, FIXME, HACK, NOTE, WARN, BUG and other keywords across all file types"

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -3,7 +3,7 @@ use zed_extension_api::{self as zed, Architecture, DownloadedFileType, LanguageS
 /// Version of the LSP binary to download from GitHub Releases.
 /// Must match the release tag (without the leading "v") when publishing.
 /// Update all four version fields together — see CLAUDE.md.
-const LSP_VERSION: &str = "0.1.0";
+const LSP_VERSION: &str = "0.2.0";
 
 struct TodoHighlightExtension {
     cached_binary_path: Option<String>,

--- a/lsp/Cargo.toml
+++ b/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-highlight-lsp"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Bump all four version fields to 0.2.0 for the renamed release (todo-highlight-lsp binaries).