### PR TITLE
fix: update clippy hook to use todo-highlight-lsp

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
       },
       {
         "matcher": "Write|Edit",
-        "command": "case \"$FILE_PATH\" in */lsp/src/*.rs) ~/.cargo/bin/cargo clippy -p todo-highlighter-lsp -- -D warnings 2>&1 | head -40 ;; esac",
+        "command": "case \"$FILE_PATH\" in */lsp/src/*.rs) ~/.cargo/bin/cargo clippy -p todo-highlight-lsp -- -D warnings 2>&1 | head -40 ;; esac",
         "description": "Run clippy on LSP crate after edits to lsp/src/"
       }
     ]


### PR DESCRIPTION
The PostToolUse clippy hook in `.claude/settings.json` still referenced the old `todo-highlighter-lsp` package name.