### PR TITLE
fix: rename extension ID to todo-highlight-language-server

### DIFF
--- a/extension/extension.toml
+++ b/extension/extension.toml
@@ -1,4 +1,4 @@
-id = "todo-highlight"
+id = "todo-highlight-language-server"
 name = "TODO Highlight"
 version = "0.2.0"
 schema_version = 1


### PR DESCRIPTION
Zed team reviewer requested a language-server related suffix on the extension ID, following the convention used by `cloudformation-language-server`, `postgres-language-server`, etc.

https://github.com/zed-industries/extensions/pull/6209#pullrequestreview-4403444966