### PR TITLE
fix: create bin/ directory before downloading LSP binary

### DIFF
--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -97,6 +97,10 @@ impl TodoHighlightExtension {
                 .iter()
                 .find(|a| a.name == binary_name)
                 .ok_or_else(|| format!("no asset '{binary_name}' in release v{LSP_VERSION}"))?;
+            // `download_file` writes to `binary_path` via `File::create`, which does not
+            // create missing parent directories — the `bin/` dir must exist first.
+            std::fs::create_dir_all("bin")
+                .map_err(|e| format!("failed to create 'bin' directory: {e}"))?;
             zed::download_file(&asset.download_url, &binary_path, DownloadedFileType::Uncompressed)
                 .map_err(|e| format!("Failed to download {binary_name} v{LSP_VERSION}: {e}"))?;
             // `make_file_executable` is a no-op on Windows; safe to call on all platforms.


### PR DESCRIPTION
## Summary
- Fixes #11 — `Failed to download todo-highlight-lsp-x86_64-unknown-linux-gnu v0.2.0: No such file or directory (os error 2)`
- `zed::download_file` writes the binary via `File::create`, which does not create missing parent directories. On a fresh install where the extension's `bin/` work directory doesn't exist yet, the download fails with `ENOENT`.
- Add `std::fs::create_dir_all("bin")` before calling `download_file`, matching the pattern used by other Zed extensions that download release binaries.

## Test plan
- [x] `./check.sh` passes (tests, clippy, wasm32-wasip1 build)
- [ ] Reporter confirms the extension installs successfully on Linux after this fix ships in a release