### PR TITLE
fix: improve binary distribution for cross-distro compatibility

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -62,8 +62,9 @@ git push origin vx.y.z
 ```
 
 Pushing the tag triggers `.github/workflows/release.yml`, which cross-compiles
-`todo-highlight-lsp` for every target, generates SHA-256 checksums, and creates the
-GitHub Release with all assets attached automatically.
+`todo-highlight-lsp` for every target, packages each binary as a `.tar.gz` (macOS/Linux)
+or `.zip` (Windows), generates SHA-256 checksums, and creates the GitHub Release with all
+assets attached automatically.
 
 ## Step 6 — Wait for CI and verify the release
 
@@ -74,9 +75,9 @@ gh release view vx.y.z
 ```
 
 Confirm all expected assets (and matching `.sha256` files) are present:
-- `todo-highlight-lsp-{aarch64,x86_64}-apple-darwin`
-- `todo-highlight-lsp-{aarch64,x86_64}-unknown-linux-gnu`
-- `todo-highlight-lsp-{aarch64,x86_64}-pc-windows-msvc.exe`
+- `todo-highlight-lsp-{aarch64,x86_64}-apple-darwin.tar.gz`
+- `todo-highlight-lsp-{aarch64,x86_64}-unknown-linux-musl.tar.gz`
+- `todo-highlight-lsp-{aarch64,x86_64}-pc-windows-msvc.zip`
 
 ## Step 7 — Verify the download works
 
@@ -84,5 +85,6 @@ Install the released version as a dev extension in Zed and confirm the LSP start
 
 Expected URL pattern:
 ```
-https://github.com/shionit/zed-todo-highlight/releases/download/vx.y.z/todo-highlight-lsp-{target}
+https://github.com/shionit/zed-todo-highlight/releases/download/vx.y.z/todo-highlight-lsp-{target}.tar.gz
+https://github.com/shionit/zed-todo-highlight/releases/download/vx.y.z/todo-highlight-lsp-{target}.zip  (Windows)
 ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,19 +21,26 @@ jobs:
         include:
           - os: macos-latest
             target: aarch64-apple-darwin
+            archive_suffix: .tar.gz
           - os: macos-latest
             target: x86_64-apple-darwin
+            archive_suffix: .tar.gz
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             use_cross: true
+            archive_suffix: .tar.gz
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            use_cross: true
+            archive_suffix: .tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             bin_suffix: .exe
+            archive_suffix: .zip
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             bin_suffix: .exe
+            archive_suffix: .zip
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -64,27 +71,34 @@ jobs:
         shell: bash
         run: cargo build --release -p todo-highlight-lsp --target "$TARGET"
 
-      - name: Package binary and generate SHA-256 checksum
+      - name: Package archive and generate SHA-256 checksum
         env:
           TARGET: ${{ matrix.target }}
           BIN_SUFFIX: ${{ matrix.bin_suffix }}
+          ARCHIVE_SUFFIX: ${{ matrix.archive_suffix }}
         shell: bash
         run: |
-          BIN="todo-highlight-lsp-${TARGET}${BIN_SUFFIX}"
-          cp "target/${TARGET}/release/todo-highlight-lsp${BIN_SUFFIX}" "$BIN"
+          BIN="todo-highlight-lsp${BIN_SUFFIX}"
+          ARCHIVE="todo-highlight-lsp-${TARGET}${ARCHIVE_SUFFIX}"
+          if [[ "${ARCHIVE_SUFFIX}" == ".zip" ]]; then
+            # 7-Zip is pre-installed on Windows GitHub Actions runners.
+            (cd "target/${TARGET}/release" && 7z a "../../../${ARCHIVE}" "${BIN}")
+          else
+            tar czf "${ARCHIVE}" -C "target/${TARGET}/release" "${BIN}"
+          fi
           # sha256sum on Linux/Windows (Git Bash), shasum on macOS
           if command -v sha256sum &>/dev/null; then
-            sha256sum "$BIN" | awk '{print $1}' > "${BIN}.sha256"
+            sha256sum "${ARCHIVE}" | awk '{print $1}' > "${ARCHIVE}.sha256"
           else
-            shasum -a 256 "$BIN" | awk '{print $1}' > "${BIN}.sha256"
+            shasum -a 256 "${ARCHIVE}" | awk '{print $1}' > "${ARCHIVE}.sha256"
           fi
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.target }}
           path: |
-            todo-highlight-lsp-${{ matrix.target }}${{ matrix.bin_suffix }}
-            todo-highlight-lsp-${{ matrix.target }}${{ matrix.bin_suffix }}.sha256
+            todo-highlight-lsp-${{ matrix.target }}${{ matrix.archive_suffix }}
+            todo-highlight-lsp-${{ matrix.target }}${{ matrix.archive_suffix }}.sha256
 
   release:
     name: Create GitHub Release
@@ -95,7 +109,7 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Publish release with binaries and checksums
+      - name: Publish release with archives and checksums
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: todo-highlight-lsp-*

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -65,14 +65,15 @@ impl TodoHighlightExtension {
     fn download_binary(&self) -> Result<String> {
         let (os, arch) = zed::current_platform();
 
-        // `exe_suffix` is ".exe" on Windows and "" everywhere else.
+        // Linux uses musl targets to produce fully-static binaries that run on any
+        // distro (NixOS, Alpine, etc.) without relying on a system glibc.
         let (target, exe_suffix) = match (os, arch) {
-            (Os::Mac, Architecture::Aarch64)     => ("aarch64-apple-darwin",           ""),
-            (Os::Mac, Architecture::X8664)       => ("x86_64-apple-darwin",            ""),
-            (Os::Linux, Architecture::Aarch64)   => ("aarch64-unknown-linux-gnu",      ""),
-            (Os::Linux, Architecture::X8664)     => ("x86_64-unknown-linux-gnu",       ""),
-            (Os::Windows, Architecture::X8664)   => ("x86_64-pc-windows-msvc",   ".exe"),
-            (Os::Windows, Architecture::Aarch64) => ("aarch64-pc-windows-msvc",  ".exe"),
+            (Os::Mac, Architecture::Aarch64)     => ("aarch64-apple-darwin",        ""),
+            (Os::Mac, Architecture::X8664)       => ("x86_64-apple-darwin",         ""),
+            (Os::Linux, Architecture::Aarch64)   => ("aarch64-unknown-linux-musl",  ""),
+            (Os::Linux, Architecture::X8664)     => ("x86_64-unknown-linux-musl",   ""),
+            (Os::Windows, Architecture::X8664)   => ("x86_64-pc-windows-msvc",  ".exe"),
+            (Os::Windows, Architecture::Aarch64) => ("aarch64-pc-windows-msvc", ".exe"),
             (os, arch) => {
                 return Err(format!(
                     "todo-highlight-lsp has no pre-built binary for {os:?}/{arch:?}. \
@@ -81,13 +82,23 @@ impl TodoHighlightExtension {
             }
         };
 
-        let binary_name = format!("todo-highlight-lsp-{target}{exe_suffix}");
+        // Windows ships as .zip; macOS and Linux ship as .tar.gz.
+        let (archive_ext, file_type) = if exe_suffix.is_empty() {
+            (".tar.gz", DownloadedFileType::GzipTar)
+        } else {
+            (".zip", DownloadedFileType::Zip)
+        };
 
-        // Version in the path prevents a stale cached binary from being reused
-        // after an extension upgrade.
-        let binary_path = format!("bin/todo-highlight-lsp-{target}-v{LSP_VERSION}{exe_suffix}");
+        let asset_name = format!("todo-highlight-lsp-{target}{archive_ext}");
+
+        // Version-specific directory: lets download_file extract the archive in place,
+        // and lets cleanup_old_versions identify stale directories to remove.
+        let version_dir = format!("bin/todo-highlight-lsp-{target}-v{LSP_VERSION}");
+        let binary_path = format!("{version_dir}/todo-highlight-lsp{exe_suffix}");
 
         if !std::path::Path::new(&binary_path).exists() {
+            self.cleanup_old_versions(target)?;
+
             let release = zed::github_release_by_tag_name(
                 "shionit/zed-todo-highlight",
                 &format!("v{LSP_VERSION}"),
@@ -95,19 +106,41 @@ impl TodoHighlightExtension {
             let asset = release
                 .assets
                 .iter()
-                .find(|a| a.name == binary_name)
-                .ok_or_else(|| format!("no asset '{binary_name}' in release v{LSP_VERSION}"))?;
-            // `download_file` writes to `binary_path` via `File::create`, which does not
-            // create missing parent directories — the `bin/` dir must exist first.
+                .find(|a| a.name == asset_name)
+                .ok_or_else(|| format!("no asset '{asset_name}' in release v{LSP_VERSION}"))?;
+
+            // `download_file` requires the parent directory to exist.
             std::fs::create_dir_all("bin")
                 .map_err(|e| format!("failed to create 'bin' directory: {e}"))?;
-            zed::download_file(&asset.download_url, &binary_path, DownloadedFileType::Uncompressed)
-                .map_err(|e| format!("Failed to download {binary_name} v{LSP_VERSION}: {e}"))?;
+
+            // For GzipTar/Zip, download_file extracts the archive into version_dir,
+            // placing the binary at version_dir/todo-highlight-lsp[.exe].
+            zed::download_file(&asset.download_url, &version_dir, file_type)
+                .map_err(|e| format!("Failed to download {asset_name} v{LSP_VERSION}: {e}"))?;
+
             // `make_file_executable` is a no-op on Windows; safe to call on all platforms.
             zed::make_file_executable(&binary_path)?;
         }
 
         Ok(binary_path)
+    }
+
+    /// Removes version directories for `target` that don't match the current LSP_VERSION.
+    /// Silently ignores missing or unreadable directories.
+    fn cleanup_old_versions(&self, target: &str) -> Result<()> {
+        let current = format!("todo-highlight-lsp-{target}-v{LSP_VERSION}");
+        let prefix = format!("todo-highlight-lsp-{target}-v");
+        let Ok(entries) = std::fs::read_dir("bin") else {
+            return Ok(());
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with(&prefix) && name != current {
+                std::fs::remove_dir_all(entry.path()).ok();
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Addresses the NixOS follow-up from #11 and aligns the release pipeline with Zed extension best practices observed across major LSP extensions.

### Changes

**`extension/src/lib.rs`**
- Linux targets: `*-linux-gnu` → `*-linux-musl` — fully-static binaries, no glibc dependency. Fixes launch failure on NixOS, Alpine, and any distro where the standard dynamic linker is absent.
- Archive format: `Uncompressed` → `GzipTar` (macOS/Linux) / `Zip` (Windows) — matches the convention used by every major Zed LSP extension; smaller download, no raw-binary transfer.
- Version-specific directories + `cleanup_old_versions()` — binary is extracted into `bin/todo-highlight-lsp-{target}-v{VERSION}/` and stale directories from prior versions are removed on upgrade.

**`.github/workflows/release.yml`**
- Linux matrix entries switched to `x86_64/aarch64-unknown-linux-musl` (both use `cross`).
- Packaging step now produces `.tar.gz` (macOS/Linux) and `.zip` (Windows) archives via `tar`/`7z`.
- Artifact upload paths updated to match the new archive filenames.

**`.claude/skills/publish-release/SKILL.md`**
- Step 6 asset list updated: `linux-gnu` → `linux-musl`, archive extensions added.
- Step 7 URL pattern updated to include `.tar.gz`/`.zip` extension.

## Test plan
- [x] `./check.sh` passes (tests, clippy, wasm32-wasip1 build)
- [ ] After merge and version bump, verify CI produces `.tar.gz`/`.zip` archives for all 6 targets
- [ ] Confirm extension installs and LSP starts on NixOS (reporter from #11)