### PR TITLE
feat: add ini, Plain Text and Jinja2 to supported languages

### DIFF
--- a/extension/extension.toml
+++ b/extension/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/shionit/zed-todo-highlight"
 
 [language_servers.todo-highlight-lsp]
 name = "TODO Highlight LSP"
-languages = ["Rust", "Python", "JavaScript", "TypeScript", "Go", "C", "C++", "Java", "Ruby", "PHP", "Swift", "Kotlin", "Shell Script", "Markdown", "YAML", "TOML", "JSON", "CSS", "HTML", "Lua", "Zig", "Elixir", "Haskell", "Scala", "Dart", "R"]
+languages = ["Rust", "Python", "JavaScript", "TypeScript", "Go", "C", "C++", "Java", "Ruby", "PHP", "Swift", "Kotlin", "Shell Script", "Markdown", "YAML", "TOML", "JSON", "CSS", "HTML", "Lua", "Zig", "Elixir", "Haskell", "Scala", "Dart", "R", "ini", "Plain Text", "Jinja2"]


### PR DESCRIPTION
Registers todo-highlight-lsp for the ini, Plain Text and Jinja2 languages so TODO keywords are highlighted in .ini, .txt and .j2 files. Zed only attaches extension-provided language servers to languages declared in the extension manifest, so users cannot add these via the language_servers setting themselves.

▎ ini and Jinja2 are registered by the ini and ansible extensions; for users without them the entries are inert.